### PR TITLE
lakeFS data lake recipe

### DIFF
--- a/src/mlstacks/enums.py
+++ b/src/mlstacks/enums.py
@@ -31,6 +31,7 @@ class ComponentTypeEnum(str, Enum):
     FEATURE_STORE = "feature_store"
     ANNOTATOR = "annotator"
     IMAGE_BUILDER = "image_builder"
+    DATA_LAKE = "data_lake"
 
 
 class ComponentFlavorEnum(str, Enum):
@@ -40,6 +41,7 @@ class ComponentFlavorEnum(str, Enum):
     GCP = "gcp"
     KUBEFLOW = "kubeflow"
     KUBERNETES = "kubernetes"
+    LAKEFS = "lakefs"
     MINIO = "minio"
     MLFLOW = "mlflow"
     S3 = "s3"

--- a/src/mlstacks/terraform/k3d-modular/k3d.tf
+++ b/src/mlstacks/terraform/k3d-modular/k3d.tf
@@ -17,7 +17,7 @@ resource "k3d_registry" "zenml-registry" {
   image = "docker.io/registry:2"
   count = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? 1 : 0
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? 1 : 0
 
   port {
     host_port = local.k3d_registry.port
@@ -53,7 +53,7 @@ resource "k3d_cluster" "zenml-cluster" {
   agents  = 2
   count = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? 1 : 0
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? 1 : 0
 
   kube_api {
     host    = local.k3d_kube_api.host

--- a/src/mlstacks/terraform/k3d-modular/kubernetes.tf
+++ b/src/mlstacks/terraform/k3d-modular/kubernetes.tf
@@ -2,31 +2,31 @@
 provider "kubernetes" {
   host = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.host : ""
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.host : ""
   client_certificate = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.client_certificate : ""
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.client_certificate : ""
   client_key = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.client_key : ""
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.client_key : ""
   cluster_ca_certificate = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.cluster_ca_certificate : ""
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.cluster_ca_certificate : ""
 }
 
 provider "kubectl" {
   host = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.host : ""
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.host : ""
   client_certificate = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.client_certificate : ""
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.client_certificate : ""
   client_key = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.client_key : ""
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.client_key : ""
   cluster_ca_certificate = (var.enable_container_registry || var.enable_orchestrator_kubeflow ||
     var.enable_orchestrator_tekton || var.enable_orchestrator_kubernetes ||
-  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.cluster_ca_certificate : ""
+  var.enable_model_deployer_seldon || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs || var.enable_artifact_store || var.enable_zenml) ? k3d_cluster.zenml-cluster[0].credentials.0.cluster_ca_certificate : ""
 }
 
 # the namespace where zenml will run kubernetes orchestrator workloads

--- a/src/mlstacks/terraform/k3d-modular/lakefs.tf
+++ b/src/mlstacks/terraform/k3d-modular/lakefs.tf
@@ -1,0 +1,45 @@
+module "lakefs" {
+  source = "../modules/lakefs-module"
+
+  count = var.enable_data_lake_lakefs ? 1 : 0
+
+  # run only after the cluster, ingress controller, and minio are set up
+  depends_on = [
+    k3d_cluster.zenml-cluster,
+    module.nginx-ingress,
+    module.istio,
+    module.minio_server,
+    minio_s3_bucket.lakefs_bucket,
+  ]
+
+  # details about the lakefs deployment
+  chart_version           = local.lakefs.version
+  ingress_host            = (var.enable_model_deployer_seldon) ? "${local.lakefs.ingress_host_prefix}.${module.istio[0].ingress-ip-address}.nip.io" : "${local.lakefs.ingress_host_prefix}.${module.nginx-ingress[0].ingress-ip-address}.nip.io"
+  tls_enabled             = false
+  istio_enabled           = (var.enable_model_deployer_seldon) ? true : false
+  storage_S3              = true
+  storage_S3_Access_Key   = var.zenml-minio-store-access-key
+  storage_S3_Secret_Key   = var.zenml-minio-store-secret-key
+  storage_S3_Bucket       = minio_s3_bucket.lakefs_bucket[0].bucket
+  storage_S3_Endpoint_URL = module.minio_server[0].artifact_S3_Endpoint_URL
+}
+
+resource "random_string" "lakefs_bucket_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+# Create a bucket for lakeFS to use
+resource "minio_s3_bucket" "lakefs_bucket" {
+  count = (var.enable_data_lake_lakefs && var.lakefs_minio_bucket == "") ? 1 : 0
+
+  bucket        = "lakefs-minio-${random_string.lakefs_bucket_suffix.result}"
+  force_destroy = true
+
+  depends_on = [
+    module.minio_server,
+    module.nginx-ingress,
+    module.istio,
+  ]
+}

--- a/src/mlstacks/terraform/k3d-modular/locals.tf
+++ b/src/mlstacks/terraform/k3d-modular/locals.tf
@@ -54,6 +54,11 @@ locals {
     ingress_host_prefix     = "mlflow"
   }
 
+  lakefs = {
+    version             = "1.0.12"
+    ingress_host_prefix = "lakefs"
+  }
+
   seldon = {
     version              = "1.15.0"
     name                 = "seldon"

--- a/src/mlstacks/terraform/k3d-modular/minio.tf
+++ b/src/mlstacks/terraform/k3d-modular/minio.tf
@@ -1,5 +1,5 @@
 locals {
-  enable_minio = (var.enable_artifact_store || var.enable_experiment_tracker_mlflow)
+  enable_minio = (var.enable_artifact_store || var.enable_experiment_tracker_mlflow || var.enable_data_lake_lakefs)
 }
 module "minio_server" {
   source = "../modules/minio-module"

--- a/src/mlstacks/terraform/k3d-modular/nginx_ingress.tf
+++ b/src/mlstacks/terraform/k3d-modular/nginx_ingress.tf
@@ -2,7 +2,7 @@
 module "nginx-ingress" {
   source = "../modules/nginx-ingress-module"
 
-  count = (var.enable_experiment_tracker_mlflow || var.enable_orchestrator_kubeflow || var.enable_orchestrator_tekton || var.enable_artifact_store) && (!var.enable_model_deployer_seldon) ? 1 : 0
+  count = (var.enable_experiment_tracker_mlflow || var.enable_orchestrator_kubeflow || var.enable_orchestrator_tekton || var.enable_artifact_store || var.enable_data_lake_lakefs) && (!var.enable_model_deployer_seldon) ? 1 : 0
 
   # run only after the gke cluster is set up
   depends_on = [

--- a/src/mlstacks/terraform/k3d-modular/variables.tf
+++ b/src/mlstacks/terraform/k3d-modular/variables.tf
@@ -31,7 +31,10 @@ variable "enable_zenml" {
   description = "Enable ZenML deployment"
   default     = false
 }
-
+variable "enable_data_lake_lakefs" {
+  description = "Enable lakeFS data lake"
+  default     = false
+}
 
 # variables for the MLflow tracking server and Minio S3 bucket
 variable "zenml-minio-store-access-key" {
@@ -63,6 +66,12 @@ variable "seldon-secret-name" {
   description = "The Seldon Core Model Deployer Secret name"
   default     = "zenml-seldon-secret"
   type        = string
+}
+
+# variables for the lakeFS data lake
+variable "lakefs_minio_bucket" {
+  description = "The name of the Minio bucket to use for lakeFS data lake. If no name is provided, a new bucket will be created."
+  default     = ""
 }
 
 # variables for creating a ZenML stack configuration file

--- a/src/mlstacks/terraform/modules/lakefs-module/README.md
+++ b/src/mlstacks/terraform/modules/lakefs-module/README.md
@@ -1,0 +1,48 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.8 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0.1 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 1.14.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.11.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.0.3 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.11.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [helm_release.lakefs](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_namespace.lakefs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | n/a | `string` | `"1.0.12"` | no |
+| <a name="input_ingress_host"></a> [ingress\_host](#input\_ingress\_host) | n/a | `string` | `""` | no |
+| <a name="input_istio_enabled"></a> [istio\_enabled](#input\_istio\_enabled) | n/a | `bool` | `false` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | n/a | `string` | `"lakefs"` | no |
+| <a name="input_storage_S3"></a> [storage\_S3](#input\_storage\_S3) | Storage-related variables | `bool` | `false` | no |
+| <a name="input_storage_S3_Access_Key"></a> [storage\_S3\_Access\_Key](#input\_storage\_S3\_Access\_Key) | n/a | `string` | `""` | no |
+| <a name="input_storage_S3_Bucket"></a> [storage\_S3\_Bucket](#input\_storage\_S3\_Bucket) | n/a | `string` | `""` | no |
+| <a name="input_storage_S3_Endpoint_URL"></a> [storage\_S3\_Endpoint\_URL](#input\_storage\_S3\_Endpoint\_URL) | n/a | `string` | `""` | no |
+| <a name="input_storage_S3_Region"></a> [storage\_S3\_Region](#input\_storage\_S3\_Region) | n/a | `string` | `"us-east-1"` | no |
+| <a name="input_storage_S3_Secret_Key"></a> [storage\_S3\_Secret\_Key](#input\_storage\_S3\_Secret\_Key) | n/a | `string` | `""` | no |
+| <a name="input_tls_enabled"></a> [tls\_enabled](#input\_tls\_enabled) | n/a | `bool` | `true` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/src/mlstacks/terraform/modules/lakefs-module/lakefs.tf
+++ b/src/mlstacks/terraform/modules/lakefs-module/lakefs.tf
@@ -1,0 +1,98 @@
+# create the lakeFS namespace
+resource "kubernetes_namespace" "lakefs" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+locals {
+  lakefsConfig = {
+    database = {
+      type = "local"
+    }
+    installation = {
+      user_name         = "admin"
+      access_key_id     = "admin"
+      secret_access_key = "supersafepassword"
+    }
+    stats = {
+      enabled = false
+    }
+    blockstore = {
+      type = "s3"
+      s3 = {
+        region           = var.storage_S3_Region,
+        endpoint         = "${var.storage_S3_Endpoint_URL}/${var.storage_S3_Bucket}"
+        force_path_style = true
+        credentials = {
+          access_key_id     = var.storage_S3_Access_Key,
+          secret_access_key = var.storage_S3_Secret_Key
+        }
+      }
+    }
+  }
+}
+
+# create the lakeFS deployment
+resource "helm_release" "lakefs" {
+  name       = "lakefs"
+  repository = "https://charts.lakefs.io"
+  chart      = "lakefs"
+  version    = var.chart_version
+
+  namespace = kubernetes_namespace.lakefs.metadata[0].name
+
+  # set ingress 
+  set {
+    name  = "ingress.enabled"
+    value = var.ingress_host != "" ? true : false
+    type  = "auto"
+  }
+  set {
+    name  = "ingress.ingressClassName"
+    value = var.istio_enabled ? "istio" : "nginx"
+    type  = "string"
+  }
+  set {
+    name  = "ingress.hosts[0].host"
+    value = var.ingress_host
+    type  = "string"
+  }
+  set {
+    name  = "ingress.hosts[0].paths[0]"
+    value = "/"
+    type  = "string"
+  }
+  set {
+    name  = "ingress.hosts[0].paths[0].pathType"
+    value = "Prefix"
+    type  = "string"
+  }
+  dynamic "set" {
+    for_each = var.tls_enabled ? [var.ingress_host] : []
+    content {
+      name  = "ingress.tls[0].hosts[0]"
+      value = set.value
+      type  = "string"
+    }
+  }
+  dynamic "set" {
+    for_each = var.tls_enabled ? ["lakefs-tls"] : []
+    content {
+      name  = "ingress.tls[0].secretName"
+      value = set.value
+      type  = "string"
+    }
+  }
+  set {
+    name  = "ingress.annotations.nginx\\.ingress\\.kubernetes\\.io/ssl-redirect"
+    value = var.tls_enabled
+    type  = "string"
+  }
+
+  values = [
+    templatefile("${path.module}/values.yaml.tftpl", {
+      config = local.lakefsConfig
+    })
+  ]
+}

--- a/src/mlstacks/terraform/modules/lakefs-module/providers.tf
+++ b/src/mlstacks/terraform/modules/lakefs-module/providers.tf
@@ -1,0 +1,18 @@
+# defining the providers required by the mlflow module
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.11.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "1.14.0"
+    }
+  }
+  required_version = ">= 0.14.8"
+}

--- a/src/mlstacks/terraform/modules/lakefs-module/values.yaml.tftpl
+++ b/src/mlstacks/terraform/modules/lakefs-module/values.yaml.tftpl
@@ -1,0 +1,2 @@
+lakefsConfig: |
+  ${indent(2, yamlencode(config))}

--- a/src/mlstacks/terraform/modules/lakefs-module/variables.tf
+++ b/src/mlstacks/terraform/modules/lakefs-module/variables.tf
@@ -1,0 +1,50 @@
+variable "namespace" {
+  type    = string
+  default = "lakefs"
+}
+
+variable "chart_version" {
+  type    = string
+  default = "1.0.12"
+}
+
+variable "ingress_host" {
+  type    = string
+  default = ""
+}
+
+variable "tls_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "istio_enabled" {
+  type    = bool
+  default = false
+}
+
+# Storage-related variables
+variable "storage_S3" {
+  type    = bool
+  default = false
+}
+variable "storage_S3_Region" {
+  type    = string
+  default = "us-east-1"
+}
+variable "storage_S3_Bucket" {
+  type    = string
+  default = ""
+}
+variable "storage_S3_Access_Key" {
+  type    = string
+  default = ""
+}
+variable "storage_S3_Secret_Key" {
+  type    = string
+  default = ""
+}
+variable "storage_S3_Endpoint_URL" {
+  type    = string
+  default = ""
+}

--- a/src/mlstacks/utils/terraform_utils.py
+++ b/src/mlstacks/utils/terraform_utils.py
@@ -42,6 +42,7 @@ HIGH_LEVEL_COMPONENTS = [
     "experiment_tracker",
     "model_deployer",
     "step_operator",
+    "data_lake",
 ]
 
 CONFIG_DIR = get_app_dir(MLSTACKS_PACKAGE_NAME)


### PR DESCRIPTION
## Describe changes

This PR adds support for the [lakeFS](https://lakefs.io) data lake to MLStacks.

It adds a new high-level component type `data_lake` with `lakefs` as its only flavor.

At this point, only deployment on a local k3d cluster with MinIO as the storage backend is supported.

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [] If my change requires a change to docs, I have updated the documentation
      accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting
      `develop`. If your branch wasn't based on develop read
      [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/mlstacks/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [ ] Other (add details above)
